### PR TITLE
fixed package.json

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "homepage": "",
   "devDependencies": {
-    "embark-framework": "embark-framework@develop",
+    "embark-framework": "iurimatias/embark-framework#develop",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-coffee": "^0.13.0",
     "grunt-contrib-concat": "^0.5.1",


### PR DESCRIPTION
`embark demo` that you suggested in #20 was failing with:

```
npm WARN package.json app_name@0.0.1 No description
npm WARN package.json app_name@0.0.1 No repository field.
npm WARN package.json app_name@0.0.1 No README data
npm ERR! Darwin 14.3.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.4
npm ERR! npm  v2.11.1
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: embark-framework@'embark-framework@develop'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.0.1","0.0.2","0.0.3","0.0.4","0.0.5","0.0.6","0.0.7","0.0.8","0.1.0","0.1.1","0.1.2","0.2.0","0.2.1","0.3.0","0.4.0","0.4.1","0.4.2","0.4.3"]
npm ERR! notarget
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'app_name'
npm ERR! notarget

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/marekkotewicz/ethereum/embark_demo/npm-debug.log
```