### PR TITLE
Allow blockchain rpchost to be configurable

### DIFF
--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -18,6 +18,7 @@ Blockchain.prototype.generate_basic_command = function() {
   cmd += "--port " + config.port + " ";
   cmd += "--rpc ";
   cmd += "--rpcport " + config.rpcPort + " ";
+  cmd += "--rpcaddr " + config.rpcHost + " ";
   cmd += "--networkid " + config.networkId + " ";
   cmd += "--rpccorsdomain \"" + config.rpcWhitelist + "\" ";
 


### PR DESCRIPTION
Hello this PR allows the `embark blockchain` command to specify the `rpcHost` from the configuration.