### PR TITLE
Add option to run geth with any command

### DIFF
--- a/bin/embark
+++ b/bin/embark
@@ -139,6 +139,18 @@ program.command('blockchain [env]').description('run blockchain').action(functio
   }
 });
 
+program.command('geth <env> [args...]').description('run geth with specified arguments').action(function(env_, args_) {
+  var env = env_ || 'development';
+  var embarkConfig = readYaml.sync("./embark.yml");
+  var args = args_.join(' ');
+
+  Embark.init()
+  Embark.blockchainConfig.loadConfigFile(embarkConfig.blockchainConfig)
+  Embark.contractsConfig.loadConfigFile(embarkConfig.contractsConfig)
+
+  Embark.geth(env, args);
+});
+
 program.command('demo').description('create a working dapp with a SimpleStorage contract').action(function() {
   var boilerPath = path.join(__dirname + '/../boilerplate');
   var demoPath   = path.join(__dirname + '/../demo');
@@ -169,4 +181,3 @@ if (!process.argv.slice(2).length) {
 }
 
 exit();
-

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -57,6 +57,10 @@ Blockchain.prototype.init_command = function() {
   return this.generate_basic_command() + "account new ";
 }
 
+Blockchain.prototype.geth_command = function(geth_args) {
+  return this.generate_basic_command() + geth_args;
+}
+
 Blockchain.prototype.run_command = function(address, use_tmp) {
   var cmd = this.generate_basic_command();
   var config = this.config;
@@ -114,6 +118,12 @@ Blockchain.prototype.startChain = function(use_tmp) {
   var address = this.get_address();
   console.log("running: " + this.run_command(address, use_tmp));
   exec(this.run_command(address, use_tmp));
+}
+
+Blockchain.prototype.execGeth = function(args) {
+  var cmd = this.geth_command(args);
+  console.log("executing: " + cmd);
+  exec(cmd);
 }
 
 module.exports = Blockchain

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,8 +44,12 @@ Embark = {
     return deploy.generate_abi_file(destFile);
   },
 
+  geth: function(env, args) {
+    var chain = new Blockchain(this.blockchainConfig.config(env));
+    chain.execGeth(args);
+  },
+
   release: Release
 }
 
 module.exports = Embark;
-


### PR DESCRIPTION
Hello,

I've added the option to run geth with any argument/command. Advantage is this allows me to run geth on the development chain with the configuration embark uses.
Our immediate motive was that we use the development environment for local testing/development and easy interacting with ethereum can be handy then.

Open for suggestions or critique.