### PR TITLE
Alter require to support `npm link`

### DIFF
--- a/bin/embark
+++ b/bin/embark
@@ -6,7 +6,7 @@ var wrench = require('wrench');
 var grunt = require('grunt');
 require('shelljs/global');
 var readYaml = require('read-yaml');
-var Embark = require('embark-framework');
+var Embark = require('..');
 
 var run = function(cmd) {
   if (exec(cmd).code != 0) {
@@ -169,4 +169,3 @@ if (!process.argv.slice(2).length) {
 }
 
 exit();
-


### PR DESCRIPTION
When altering this framework locally, I use [npm link](https://docs.npmjs.com/cli/link) to use my local framework version from my local project.  This simple change makes it work locally, and (I'm 99% confident) should work fine in the final npm module as well.