### PR TITLE
lib/config: dependency-resolved single mega build vs. small files

### DIFF
--- a/lib/config/contracts.js
+++ b/lib/config/contracts.js
@@ -70,34 +70,43 @@ ContractsConfig.prototype.compileContracts = function(env) {
           this.contractDependencies[className].push(arg.substr(1));
         }
       }
-
       this.contractStubs[className] = options.stubs;
     }
   }
 
-  var all_compiled_contracts = {};
-  // compile files
-  for (j = 0; j < this.contractFiles.length; j++) {
-    contractFile = this.contractFiles[j];
-    source = fs.readFileSync(contractFile).toString()
+  // Merge all files into a single source blob (resolving dependencies)
+  var contracts = {};
+  var dependencies = [];
+  for (var i = 0; i < this.contractFiles.length; i++) {
+    var name = this.contractFiles[i];
+    var code = fs.readFileSync(name).toString();
 
-    compiled_contracts = this.compiler.compile(source);
-    for (var className in compiled_contracts) {
-      var contract = compiled_contracts[className];
+    var importer = /import \"([a-zA-Z0-9_\\./]+)\";/g;
+    while (match = importer.exec(code)) {
+      dependencies.push([name, match[1]]);
+    }
+    contracts[name] = code.replace(importer, "")
+  }
+  var sources = toposort(dependencies).reverse(), source = "";
+  for (var i = 0; i < sources.length; i++) {
+    source += contracts[sources[i]];
+  }
+  // Compile the master source file and extract the individual contracts
+  var compilations = {};
 
-      if (this.is_a_token(className, compiled_contracts)) {
-        continue;
-      }
-
-      all_compiled_contracts[className] = contract;
-      this.all_contracts.push(className);
-      this.contractDB[className] = {
-        args: [],
-        types: ['file'],
-        gasPrice: this.blockchainConfig.gasPrice,
-        gasLimit: this.blockchainConfig.gasLimit,
-        compiled: contract
-      }
+  var results = this.compiler.compile(source);
+  for (var field in results) {
+    if (this.is_a_token(field, results)) {
+      continue;
+    }
+    compilations[field] = results[field];
+    this.all_contracts.push(field);
+    this.contractDB[field] = {
+      args: [],
+      types: ['file'],
+      gasPrice: this.blockchainConfig.gasPrice,
+      gasLimit: this.blockchainConfig.gasLimit,
+      compiled: results[field]
     }
   }
 
@@ -127,7 +136,7 @@ ContractsConfig.prototype.compileContracts = function(env) {
     if (contractConfig.instanceOf !== undefined) {
       contract.types.push('instance');
       contract.instanceOf = contractConfig.instanceOf;
-      contract.compiled = all_compiled_contracts[contractConfig.instanceOf];
+      contract.compiled = compilations[contractConfig.instanceOf];
     }
     if (contractConfig.address !== undefined) {
       contract.types.push('static');
@@ -161,4 +170,3 @@ ContractsConfig.prototype.sortContracts = function() {
 };
 
 module.exports = ContractsConfig;
-


### PR DESCRIPTION
Embark previously build each source file individually. This will not work if the sources have dependencies, as those are unavailable during build. This PR retrieves all the dependencies of each source file, does a topological sort on them to get the correct "import" order, and then builds the entire source tree from a single huge master file with all the imported pieces correctly ordered.