### PR TITLE
Don't loadNpmTasks grunt-cli (not needed)

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -23,7 +23,7 @@ module.exports = (grunt) ->
         src: ['test/**/*.js']
 
   grunt.loadTasks "tasks"
-  require('matchdep').filterAll('grunt-*').forEach(grunt.loadNpmTasks)
+  require('matchdep').filterAll(['grunt-*','!grunt-cli']).forEach(grunt.loadNpmTasks)
 
   grunt.registerTask 'default', ['clean']
   grunt.registerTask 'build', ['clean', 'coffee']


### PR DESCRIPTION
This was causing a "grunt-cli not found" message even when you had the grunt-cli npm module installed.