### PR TITLE
implement `getStartBlockchainCommand` to return geth CLI string within app

### DIFF
--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -126,4 +126,9 @@ Blockchain.prototype.execGeth = function(args) {
   exec(cmd);
 }
 
+Blockchain.prototype.getStartChainCommand = function(use_tmp) {
+  var address = this.get_address();
+  return this.run_command(address, use_tmp);
+}
+
 module.exports = Blockchain

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,11 @@ Embark = {
     chain.startChain(use_tmp);
   },
 
+  getStartBlockchainCommand: function(env, use_tmp) {
+    var chain = new Blockchain(this.blockchainConfig.config(env));
+    return chain.getStartChainCommand(use_tmp);
+  },
+
   deployContracts: function(env, contractFiles, destFile, chainFile) {
     this.contractsConfig.init(contractFiles, env);
 


### PR DESCRIPTION
This function behaves as follows:

```
gethCommand = Embark.getStartBlockchainCommand(env, true)
console.log gethCommand
# geth --datadir="/tmp/embark" --logfile="/tmp/embark.log" --port 30303 --rpc --rpcport 8.....
```

I implemented it because I want to `spawn` a child process rather than blocking with `exec`, but this method may have other uses like checking the config before executing or for tests.