### PR TITLE
make `copyMinerJavascriptToTemp` step public

### DIFF
--- a/bin/embark
+++ b/bin/embark
@@ -132,8 +132,7 @@ program.command('blockchain [env]').description('run blockchain').action(functio
     Embark.blockchainConfig.loadConfigFile(embarkConfig.blockchainConfig)
     Embark.contractsConfig.loadConfigFile(embarkConfig.contractsConfig)
 
-    //TODO: better with --exec, but need to fix console bug first
-    wrench.copyDirSyncRecursive(__dirname + "/../js", "/tmp/js", {forceDelete: true});
+    Embark.copyMinerJavascriptToTemp();
 
     Embark.startBlockchain(env, true);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,11 @@ Embark = {
     chain.startChain(use_tmp);
   },
 
+  copyMinerJavascriptToTemp: function(){
+    //TODO: better with --exec, but need to fix console bug first
+    wrench.copyDirSyncRecursive(__dirname + "/../js", "/tmp/js", {forceDelete: true});
+  },
+
   getStartBlockchainCommand: function(env, use_tmp) {
     var chain = new Blockchain(this.blockchainConfig.config(env));
     return chain.getStartChainCommand(use_tmp);


### PR DESCRIPTION
Needed to emulate `embark deploy` in node