### PR TITLE
Allowing to define chains file per environment/chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Tests
 
 You can run specs with ```embark spec```, it will run any files ending *_spec.js under ```spec/```.
 
-Embark includes a testing lib to fastly run & test your contracts in a EVM. 
+Embark includes a testing lib to fastly run & test your contracts in a EVM.
 
 ```Javascript
 # spec/contracts/simple_storage_spec.js
@@ -255,6 +255,7 @@ The environment is a specific blockchain configuration that can be managed at co
     rpc_port: 8101
     rpc_whitelist: "*"
     datadir: default
+    chains: chains_staging.json
     network_id: 0
     console: true
     account:
@@ -323,4 +324,3 @@ $ echo 'export PATH="$PATH:$HOME/npm-global/bin"' >>~/.bashrc
 $ source ~/.bashrc
 $ npm install -g embark-framework grunt-cli
 ```
-

--- a/bin/embark
+++ b/bin/embark
@@ -17,15 +17,12 @@ var run = function(cmd) {
 var deploy = function(env, embarkConfig) {
   var contractFiles = grunt.file.expand(embarkConfig.contracts);
   var destFile = embarkConfig.output;
-  var chainFile = embarkConfig.chains;
 
   Embark.init();
   Embark.blockchainConfig.loadConfigFile(embarkConfig.blockchainConfig);
   Embark.contractsConfig.loadConfigFile(embarkConfig.contractsConfig);
 
-  if (chainFile === undefined) {
-    chainFile = './chains.json';
-  }
+  var chainFile = Embark.blockchainConfig.blockchainConfig[env].chains || embarkConfig.chains || './chains.json';
 
   abi = Embark.deployContracts(env, contractFiles, destFile, chainFile);
   grunt.file.write(destFile, abi);

--- a/lib/config/blockchain.js
+++ b/lib/config/blockchain.js
@@ -40,6 +40,7 @@ BlockchainConfig.prototype.config = function(env) {
     minerthreads: config.minerthreads,
     genesisBlock: config.genesis_block,
     datadir: config.datadir,
+    chains: config.chains,
     networkId: networkId,
     maxPeers: 4,
     port: config.port || "30303",

--- a/test/config.blockchain.js
+++ b/test/config.blockchain.js
@@ -43,6 +43,7 @@ describe('embark.config.blockchain', function() {
           minerthreads: 1,
           genesis_block: 'config/genesis.json',
           datadir: '/tmp/embark',
+          chains: 'chains_development.json',
           mine_when_needed: true,
           gas_limit: 123,
           gas_price: 100,
@@ -67,6 +68,7 @@ describe('embark.config.blockchain', function() {
         minerthreads: 1,
         genesisBlock: 'config/genesis.json',
         datadir: '/tmp/embark',
+        chains: 'chains_development.json',
         networkId: 0,
         maxPeers: 4,
         port: "30303",
@@ -88,12 +90,13 @@ describe('embark.config.blockchain', function() {
           network_id: 0,
           minerthreads: 1,
           datadir: '/tmp/embark',
+          chains: undefined,
           mine_when_needed: true,
           console: false,
           account: {
             init: true,
             password: 'config/password'
-          }
+          },
         },
         staging: {}
       };
@@ -110,6 +113,7 @@ describe('embark.config.blockchain', function() {
         minerthreads: 1,
         genesisBlock: undefined,
         datadir: '/tmp/embark',
+        chains: undefined,
         networkId: 0,
         maxPeers: 4,
         port: "30303",


### PR DESCRIPTION
I've added the ability to configure the chains file per environment, as discussed on gitter on 3th september.
Tested with my own software. Not certain if loading of value per environment is done in the best way (embark.js), I'd suspect there's a better way to load environment specific config file.
 