### PR TITLE
Deploy synchronously

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -36,6 +36,7 @@ Compiler.prototype.compile_solidity = function(contractFiles) {
 
     compiled_object[className] = {};
     compiled_object[className].code = contract.bytecode;
+    compiled_object[className].runtimeBytecode = contract.runtimeBytecode;
     compiled_object[className].info = {};
     compiled_object[className].info.abiDefinition = JSON.parse(contract.interface);
   }

--- a/lib/config/blockchain.js
+++ b/lib/config/blockchain.js
@@ -54,7 +54,9 @@ BlockchainConfig.prototype.config = function(env) {
     whisper: config.whisper || false,
     account: config.account,
     geth_extra_opts: config.geth_extra_opts || [],
-    testnet: config.testnet || false
+    testnet: config.testnet || false,
+    geth_extra_opts: config.geth_extra_opts,
+    deploy_synchronously: config.deploy_synchronously || false
   }
 
   return config;

--- a/lib/config/blockchain.js
+++ b/lib/config/blockchain.js
@@ -33,6 +33,7 @@ BlockchainConfig.prototype.config = function(env) {
   
 
   config = {
+    env:env,
     rpcHost: config.rpc_host,
     rpcPort: config.rpc_port,
     gasLimit: config.gas_limit || 500000,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -75,15 +75,14 @@ Deploy.prototype.deploy_contract_list = function(index, env, all_contracts, cb) 
 
 Deploy.prototype.deploy_contract_list_synchronously = function(env, all_contracts, cb) {
   
-  var _this = this;
+  var _this = this
+    ,deployed_contracts_count = 0
 
   all_contracts.forEach(function(className){
     _this.deploy_a_contract(env, className, function(){
       mark_contract_as_deployed()
     });
   })
-
-  var deployed_contracts_count = 0;
 
   function mark_contract_as_deployed(){
     deployed_contracts_count ++;

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -198,6 +198,8 @@ Deploy.prototype.generate_provider_file = function() {
 Deploy.prototype.generate_abi_file = function() {
   var result = "";
 
+  result += 'blockchain = '+JSON.stringify(this.blockchainConfig)+';';
+
   for(className in this.deployedContracts) {
     var deployedContract = this.deployedContracts[className];
     var contract = this.contractDB[className];

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -54,7 +54,10 @@ Deploy.prototype.deploy_contracts = function(env, cb) {
   this.contractDB = this.contractsManager.contractDB;
   this.deployedContracts = {};
 
-  this.deploy_contract_list(all_contracts.length, env, all_contracts, cb);
+  if(this.blockchainConfig.deploy_synchronously)
+    this.deploy_contract_list_sync(env, all_contracts, cb);
+  else
+    this.deploy_contract_list(all_contracts.length, env, all_contracts, cb);
 }
 
 Deploy.prototype.deploy_contract_list = function(index, env, all_contracts, cb) {
@@ -67,6 +70,26 @@ Deploy.prototype.deploy_contract_list = function(index, env, all_contracts, cb) 
       var className = all_contracts[index - 1];
       _this.deploy_a_contract(env, className, cb);
     });
+  }
+}
+
+Deploy.prototype.deploy_contract_list_synchronously = function(env, all_contracts, cb) {
+  
+  var _this = this;
+
+  all_contracts.forEach(function(className){
+    _this.deploy_a_contract(env, className, function(){
+      mark_contract_as_deployed()
+    });
+  })
+
+  var deployed_contracts_count = 0;
+
+  function mark_contract_as_deployed(){
+    deployed_contracts_count ++;
+
+    if(deployed_contracts_count === all_contracts.length)
+      cb()
   }
 }
 

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var grunt = require('grunt');
 var readYaml = require('read-yaml');
 var Config = require('./config/config.js');
+var BigNumber = require('bignumber.js');
 
 Deploy = function(env, contractFiles, blockchainConfig, contractsConfig, chainManager, withProvider, withChain, _web3) {
   if (_web3 !== undefined) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -55,7 +55,7 @@ Deploy.prototype.deploy_contracts = function(env, cb) {
   this.deployedContracts = {};
 
   if(this.blockchainConfig.deploy_synchronously)
-    this.deploy_contract_list_sync(env, all_contracts, cb);
+    this.deploy_contract_list_synchronously(env, all_contracts, cb);
   else
     this.deploy_contract_list(all_contracts.length, env, all_contracts, cb);
 }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -188,6 +188,7 @@ Deploy.prototype.generate_abi_file = function() {
     result += className + "Contract = web3.eth.contract(" + className + "Abi);";
     result += className + " = " + className + "Contract.at('" + contractAddress + "');";
   }
+  result += 'contractDB = '+JSON.stringify(this.contractDB)+';'
 
   return result;
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "shelljs": "^0.5.0",
     "solc": "^0.1.6",
     "toposort": "^0.2.10",
-    "web3": "^0.15.0",
+    "web3": "^0.8.1",
+    "bignumber.js": "debris/bignumber.js#master",
     "wrench": "^1.5.8",
     "ethersim": "^0.1.1"
   },


### PR DESCRIPTION
Allow contracts to be deployed syncrhonously (multiple contracts in a single block). This is really useful for the testnet/livenet where waiting for blocks to be mined is a pain.