### PR TITLE
Add support for other paths for ipfs binary

### DIFF
--- a/lib/ipfs.js
+++ b/lib/ipfs.js
@@ -1,9 +1,14 @@
 require('shelljs/global');
 
 ipfs = function(build_dir) {
-  ipfs_path = "~/go/bin";
+  ipfs_bin = exec('which ipfs').output.split("\n")[0]
 
-  cmd = ipfs_path + "/ipfs add -r " + build_dir;
+  if (ipfs_bin==='ipfs not found'){
+    console.log('=== WARNING: IPFS not in an executable path. Guessing ~/go/bin/ipfs for path')
+    ipfs_bin = "~/go/bin/ipfs";
+  }
+
+  cmd = ipfs_bin + " add -r " + build_dir;
 
   console.log("=== adding " + cmd + " to ipfs");
 


### PR DESCRIPTION
I have recently installed `ipfs` from Homebrew, which does not install to `~/go/bin/ipfs`.
As a result, `embark ipfs` did not work. This patch uses `which` to use the path for `ipfs`
if it is found in the user's `PATH`. If not, it assumes `~/go/bin/ipfs` as before.