### PR TITLE
Setting web3 on Embark Test constructor

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -19,12 +19,13 @@ var Test = function(options) {
     console.log('For more information see https://github.com/ethereumjs/testrpc');
     exit();
   }
+  
+  this.web3 = new Web3();
+  this.web3.setProvider(this.sim.provider());
 };
 
 Test.prototype.deployAll = function(contractsConfig, cb) {
   var self = this;
-  this.web3 = new Web3();
-  this.web3.setProvider(this.sim.provider());
   var logger = new TestLogger({logLevel: 'debug'});
 
   async.waterfall([


### PR DESCRIPTION
This is so it can be used before deploying contracts. It has useful functions such as sha3() on it..