### PR TITLE
embark build wasn't deploying assets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,13 @@ var Embark = {
         });
       },
       function buildPipeline(abi, callback) {
-        var pipeline = new Pipeline({});
+        self.logger.trace("Building Assets");
+        var pipeline = new Pipeline({
+          buildDir: self.config.buildDir,
+          contractsFiles: self.config.contractsFiles,
+          assetFiles: self.config.assetFiles,
+          logger: self.logger
+        });
         pipeline.build(abi);
         callback();
       }


### PR DESCRIPTION
Althought the ```embark --help``` states the **build** command will deploy and build the Dapp at *dist/*, that wasn't happening. The **build** command only deploys contracts in the blockchain, but no assets are generated whatsoever.

This fixes that.