### PR TITLE
Fix broken test environment

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -39,8 +39,7 @@ Test.prototype.deployAll = function(contractsConfig, cb) {
           contractsConfig: config.contractsConfig,
           logger: logger
         });
-        contractsManager.build();
-        callback(null, contractsManager);
+        contractsManager.build(callback);
       },
       function deployContracts(contractsManager, callback) {
         var deploy = new Deploy({

--- a/lib/test.js
+++ b/lib/test.js
@@ -21,7 +21,7 @@ var Test = function(options) {
   }
   
   this.web3 = new Web3();
-  this.web3.setProvider(this.sim.provider());
+  this.web3.setProvider(this.sim.provider(options));
 };
 
 Test.prototype.deployAll = function(contractsConfig, cb) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "request": "^2.75.0",
     "serve-static": "^1.11.1",
     "shelljs": "^0.5.0",
-    "solc": "^0.4.8",
+    "solc": "0.4.8",
     "toposort": "^1.0.0",
     "web3": "^0.18.2",
     "wrench": "^1.5.8"


### PR DESCRIPTION
- Fixes usage of `contractsManager.build` to actually provide a callback.
  - Fixes `done is not a function` issues.
- Properly passes the `options` object to the sim provider
- Locks down the version of `solc` since a newer version causes compilation issues.