### PR TITLE
Updated README  to include pragma on SimpleStorage contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Embark will automatically take care of deployment for you and set all needed JS 
 
 ```Javascript
 # app/contracts/simple_storage.sol
+pragma solidity ^0.4.7;
 contract SimpleStorage {
   uint public storedData;
 


### PR DESCRIPTION
If the pragma is not specified in the SimpleStorage contract it fails to deploy. Added the pragma directive the same way it's specified in the simple_storage.sol in the demo folder.