### PR TITLE
Prevent node exception when running command 'embark blockchain'

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -23,6 +23,14 @@ Config.prototype.loadConfigFiles = function(options) {
   if (options.interceptLogs === undefined) {
     interceptLogs = true;
   }
+
+  //Check if the config file exists
+  var embarkConfigExists = fs.existsSync(options.embarkConfig);
+  if(!embarkConfigExists){
+    this.logger.error('Cannot find file ' + options.embarkConfig + '. Please ensure you are running this command inside the Dapp folder');
+    process.exit(1);
+  }
+
   this.embarkConfig = fs.readJSONSync(options.embarkConfig);
   this.embarkConfig.plugins = this.embarkConfig.plugins || {};
 

--- a/lib/core/fs.js
+++ b/lib/core/fs.js
@@ -25,6 +25,10 @@ function writeJSONSync() {
   return fs.writeJSONSync.apply(fs.writeJSONSync, arguments);
 }
 
+function existsSync(){
+  return fs.existsSync.apply(fs.existsSync, arguments);
+}
+
 // returns embarks root directory
 function embarkPath(fileOrDir) {
   return utils.joinPath(__dirname, '/../../', fileOrDir);
@@ -37,6 +41,6 @@ module.exports = {
   writeFileSync: writeFileSync,
   readJSONSync: readJSONSync,
   writeJSONSync: writeJSONSync,
+  existsSync: existsSync,
   embarkPath: embarkPath
 };
-


### PR DESCRIPTION
Implemented logic to check if file embark.json exists and to prevent NodeJS exception when running command 'embark blockchain' if file doesn't exist or command is run outside Dapp folder.