### PR TITLE
Implemented logic to show version of the connected IPFS node 

### DIFF
--- a/lib/core/services.js
+++ b/lib/core/services.js
@@ -1,6 +1,6 @@
 var Web3 = require('web3');
 var async = require('async');
-
+var http = require('http');
 var utils = require('./utils.js');
 
 var ServicesMonitor = function(options) {
@@ -60,11 +60,35 @@ ServicesMonitor.prototype.check = function() {
 
       utils.checkIsAvailable('http://localhost:5001', function(available) {
         if (available) {
-          result.push('IPFS'.green);
-        } else {
-          result.push('IPFS'.red);
+          //Ideally this method should be in an IPFS API JSONRPC wrapper
+          //The URL should also be flexible to accept non-default IPFS url
+          self.logger.trace("Checking IPFS version...");
+          http.get('http://localhost:5001/api/v0/version', function(res) {
+            var body = '';
+           res.on('data', function(d) {
+               body += d;
+           });
+           res.on('end', function() {
+               var parsed = JSON.parse(body);
+               if(parsed.Version){
+                 result.push(("IPFS " + parsed.Version).green);
+               }
+               else{
+                 result.push("IPFS".green);
+               }
+               callback(null, result);
+           });
+           res.on('error', function(err) {
+            self.logger.trace("Check IPFS version error: " + err);
+            result.push("IPFS".green);
+            callback(null, result);
+           });
+         });
         }
-        callback(null, result);
+        else {
+          result.push('IPFS'.red);
+          callback(null, result);
+        }
       });
     },
     function checkDevServer(result, callback) {


### PR DESCRIPTION
- Implemented logic to show the version of the connected IPFS node on the dashboard.
- It uses http call to the IPFS api endpoint (/api/v0/version) so no IPFS libs were used (just node http module).