### PR TITLE
Add editorconfig to boilerplate

### DIFF
--- a/boilerplate/.editorconfig
+++ b/boilerplate/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*.{js,sol,json}]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds an editorconfig to the boilerplate, with the following options:

For .js/.sol/.json
* space indents
* indentation depth of 2
* crlf line endings
* utf-8 charset
* trailing whitespace trimming
* final newline enforcement

For .md:
* prevent trimming of trailing whitespace

Note: these are all just defaults pulled from other projects, and I don't have a strong opinion on any of them, except the space indentation and depth of 2.