### PR TITLE
More testing options

### DIFF
--- a/lib/core/test.js
+++ b/lib/core/test.js
@@ -11,9 +11,9 @@ var Config = require('./config.js');
 var RunCode = require('./runCode.js');
 var TestLogger = require('./test_logger.js');
 
-var Test = function(_options) {
-  var options = _options || {};
-  var simOptions = options.simulatorOptions || {};
+var Test = function(options) {
+  this.options = _options || {};
+  var simOptions = this.options.simulatorOptions || {};
 
   try {
     this.sim = require('ethereumjs-testrpc');
@@ -39,12 +39,14 @@ var Test = function(_options) {
 
 Test.prototype.deployAll = function(contractsConfig, cb) {
   var self = this;
-  var logger = new TestLogger({logLevel: 'debug'});
+  var logger = new TestLogger({logLevel: this.options.logLevel || 'debug'});
 
   async.waterfall([
       function getConfig(callback) {
         var config = new Config({env: 'test', logger: logger});
-        config.loadConfigFiles({embarkConfig: 'embark.json', interceptLogs: false});
+        config.loadConfigFiles({
+          interceptLogs: false
+        });
         config.contractsConfig = {contracts: contractsConfig};
         callback(null, config);
       },
@@ -86,7 +88,10 @@ Test.prototype.deployAll = function(contractsConfig, cb) {
       }
       self.web3.eth.defaultAccount = accounts[0];
       RunCode.doEval(result, self.web3); // jshint ignore:line
-      cb();
+        cb(logger);
+      } else {
+        cb();
+      }
     });
   });
 };

--- a/lib/core/test.js
+++ b/lib/core/test.js
@@ -45,6 +45,7 @@ Test.prototype.deployAll = function(contractsConfig, cb) {
       function getConfig(callback) {
         var config = new Config({env: 'test', logger: logger});
         config.loadConfigFiles({
+          embarkConfig: self.options.embarkConfig || 'embark.json', 
           interceptLogs: false
         });
         config.contractsConfig = {contracts: contractsConfig};
@@ -88,6 +89,7 @@ Test.prototype.deployAll = function(contractsConfig, cb) {
       }
       self.web3.eth.defaultAccount = accounts[0];
       RunCode.doEval(result, self.web3); // jshint ignore:line
+      if (self.options.logging) {
         cb(logger);
       } else {
         cb();


### PR DESCRIPTION
* Add ability to configure `logLevel` and `logging` during contract deployment in test setup (e.g. `EmbarkSpec.deployAll`).
* Add the ability to override the base contracts config (e.g. `embark.json`)
* Persist options on the `Test` object instance.

These change might be a bit controversial, but I found them very useful when testing a contract that has many sub-contracts.  Since they're not fleshed out yet, and I want to test one of the leaf contracts in isolation, this lets me create a `leaf_contract.json` that only deploys the contract in question.

This did raise a potential issue, though: if, for example, `LeafContract` implements `Owned`, I have to list (and subsequently deploy) `Owned` in order for `LeafContract` to successfully compile.  It might be nice to be able to separate dependencies from deployed contracts, instead of deploying everything.  To rephrase, if `LeafContract` implements `Owned`, it would be nice to be able to only list `LeafContract.sol` in my `embark.json` (or overridden one for test) and still have it successfully compile, without needing to also include `Owned.sol`.