### PR TITLE
fix typo in index.js

### DIFF
--- a/demo/app/js/index.js
+++ b/demo/app/js/index.js
@@ -93,7 +93,7 @@ $(document).ready(function() {
     if (err) {
       $("#communication .error").show();
       $("#communication-controls").hide();
-+     $("#status-communication").addClass('status-offline');
+      $("#status-communication").addClass('status-offline');
     } else {
       EmbarkJS.Messages.setProvider('whisper');
       $("#status-communication").addClass('status-online');


### PR DESCRIPTION
Remove an unexpected + sign preceding a simple instruction.