### PR TITLE
Updated the link on boilerplate app (generated by embark new) 

### DIFF
--- a/boilerplate/app/index.html
+++ b/boilerplate/app/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <h3>Welcome to Embark!</h3>
-    <p>See the <a href="https://github.com/iurimatias/embark-framework/wiki">Wiki</a> to see what you can do with Embark!</p>
+    <p>See the <a href="http://embark.readthedocs.io/en/latest/index.html" target="_blank">Embark's documentation</a> to see what you can do with Embark!</p>
   </body>
 </html>


### PR DESCRIPTION
pointed it to the latest documentation instead of old wiki