### PR TITLE
replaces jslint with eshint.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -22,9 +22,6 @@ module.exports = (grunt) ->
       test:
         src: ['test/**/*.js']
 
-    jshint:
-      all: ['bin/embark', 'lib/**/*.js', 'js/mine.js', 'js/embark.js']
-
   grunt.loadTasks "tasks"
   require('matchdep').filterAll(['grunt-*','!grunt-cli']).forEach(grunt.loadNpmTasks)
 

--- a/package.json
+++ b/package.json
@@ -47,14 +47,31 @@
   "homepage": "https://github.com/iurimatias/embark-framework",
   "license": "MIT",
   "devDependencies": {
+    "eslint": "^3.17.1",
+    "eslint-config-google": "^0.7.1",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^1.0.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-mocha-test": "^0.13.2",
     "matchdep": "^1.0.1",
     "mocha": "^3.2.0",
     "mocha-sinon": "^1.1.4",
     "sinon": "^1.15.4",
     "toposort": "^1.0.0"
+  },
+  "eslintConfig": {
+    "extends": "google",
+    "rules": {
+      "comma-dangle": [
+        "error",
+        "never"
+      ],
+      "max-len": [
+        "error",
+        120
+      ],
+      "no-var": "off"
+    }
   }
 }


### PR DESCRIPTION
ESLint is far more robust and comes installed/configured within package.json. Doug's JSLint is decent but doesn't offer the best of class capabilities we need to support multiple node versions, frameworks, and other complexities this project consumes.