### PR TITLE
Show error message if unable to deploy contracts. Include ethereumjs-testrpc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ var Embark = (function () {
           });
         });
 
-        engine.deployManager.deployContracts(function() {
+        engine.deployManager.deployContracts(function(err) {
           engine.startService("fileWatcher");
           if (options.runWebserver) {
             engine.startService("webServer", {
@@ -112,12 +112,13 @@ var Embark = (function () {
               port: options.serverPort
             });
           }
-          callback();
+          callback(err);
         });
       }
     ], function(err, result) {
       if (err) {
         engine.logger.error(err.message);
+        engine.logger.info(err.stack);
       } else {
         engine.logger.setStatus("Ready".green);
         engine.logger.info("Looking for documentation? you can find it at ".cyan + "http://embark.readthedocs.io/".green.underline);
@@ -149,13 +150,14 @@ var Embark = (function () {
         callback();
       },
       function deploy(callback) {
-        engine.deployManager.deployContracts(function() {
-          callback();
+        engine.deployManager.deployContracts(function(err) {
+          callback(err);
         });
       }
     ], function(err, result) {
       if (err) {
         engine.logger.error(err.message);
+        engine.logger.debug(err.stack)
       } else {
         engine.logger.info("finished building".underline);
       }
@@ -198,4 +200,3 @@ var Embark = (function () {
 })();
 
 module.exports = Embark;
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -167,9 +167,8 @@ var Embark = (function () {
     });
   }
 
-  function initTests (options) {
-    var Test = require('./core/test.js');
-    return new Test(options);
+  function initTests () {
+    return require('./core/test.js');
   }
 
   // TODO: should deploy if it hasn't already

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,8 @@ var Embark = (function () {
         if (pluginList.length > 0) {
           engine.logger.info("loaded plugins: " + pluginList.join(", "));
         }
-
+        
+        engine.startService("web3");
         engine.startService("pipeline");
         engine.startService("abi");
         engine.startService("deployment");

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "merge": "^1.2.0",
     "serve-static": "^1.11.1",
     "shelljs": "^0.5.0",
+    "ethereumjs-testrpc": "^3.0.3",
     "solc": "0.4.8",
     "toposort": "^1.0.0",
     "web3": "^0.18.2"


### PR DESCRIPTION
Error message is self explainatory.
Include ethereumjs-testrpc to save end users another step of installing this as a global package.