### PR TITLE
fix crash in logger if message is null or undefined

### DIFF
--- a/lib/core/logger.js
+++ b/lib/core/logger.js
@@ -12,35 +12,35 @@ class Logger {
 }
 
 Logger.prototype.error = function (txt) {
-  if (!(this.shouldLog('error'))) {
+  if (!txt || !(this.shouldLog('error'))) {
     return;
   }
   this.logFunction(txt.red);
 };
 
 Logger.prototype.warn = function (txt) {
-  if (!(this.shouldLog('warn'))) {
+  if (!txt || !(this.shouldLog('warn'))) {
     return;
   }
   this.logFunction(txt.yellow);
 };
 
 Logger.prototype.info = function (txt) {
-  if (!(this.shouldLog('info'))) {
+  if (!txt || !(this.shouldLog('info'))) {
     return;
   }
   this.logFunction(txt.green);
 };
 
 Logger.prototype.debug = function (txt) {
-  if (!(this.shouldLog('debug'))) {
+  if (!txt || !(this.shouldLog('debug'))) {
     return;
   }
   this.logFunction(txt);
 };
 
 Logger.prototype.trace = function (txt) {
-  if (!(this.shouldLog('trace'))) {
+  if (!txt || !(this.shouldLog('trace'))) {
     return;
   }
   this.logFunction(txt);


### PR DESCRIPTION
I found this when trying to compile some broken solidity, the effect was that embark crashes without logging anything when it should have logged the solidity compiler error.