### PR TITLE
fix for no accounts on init with warning messages

### DIFF
--- a/lib/cmds/blockchain/blockchain.js
+++ b/lib/cmds/blockchain/blockchain.js
@@ -65,7 +65,7 @@ Blockchain.prototype.initChainAndGetAddress = function() {
 
   // check if an account already exists, create one if not, return address
   result = this.runCommand(this.client.listAccountsCommand());
-  if (result.output === undefined || result.output === '' || result.output.indexOf("Fatal") >= 0) {
+  if (result.output === undefined || result.output.match(/{(\w+)}/) === null || result.output.indexOf("Fatal") >= 0) {
     console.log("no accounts found".green);
     if (this.config.genesisBlock) {
       console.log("initializing genesis block".green);


### PR DESCRIPTION
I tried Embark today. When starting blockchain for the first time, my Embark environment raised a warning and then crashed with the following message:

> Cannot read property '1' of null

The problem is described here: https://stackoverflow.com/questions/43481948/embark-demo-not-working. The accounts check was unsafe by checking for specific error cases instead of checking that accounts were actually found in the `client.listAccountsCommand()` result.