### PR TITLE
Update web3 version to 0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "toposort": "^1.0.0",
     "underscore": "^1.8.3",
     "underscore.string": "^3.3.4",
-    "web3": "^0.18.2"
+    "web3": "^0.19.1"
   },
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],


### PR DESCRIPTION
The bignumber repo that web3 relied on was deleted so anything earlier than 0.19.1 is broken