### PR TITLE
[*] Fixing #319: option to use particular account for contract deployment

### DIFF
--- a/demo/config/contracts.json
+++ b/demo/config/contracts.json
@@ -16,6 +16,7 @@
     "gas": "auto",
     "contracts": {
       "SimpleStorage": {
+        "fromIndex": 0,
         "args": [
           100
         ]

--- a/docs/using-contracts.rst
+++ b/docs/using-contracts.rst
@@ -1,5 +1,5 @@
 Configuring & Using Contracts
-===============
+=============================
 
 Embark will automatically take care of deployment for you and set all
 needed JS bindings. For example, the contract below:
@@ -112,6 +112,39 @@ You can now deploy many instances of the same contract. e.g
       }
     }
       ...
+
+Account from which you want to deploy a contract can be specified using "from" or "fromIndex" parameters.
+
+| "from" - should be account address string.
+| "fromIndex" - should be index in accounts array as retrieved by web3.eth.getAccounts() .
+
+If both "from" and "fromIndex" are specified, the "from" will be used.
+
+Example:
+
+      .. code:: json
+
+          # config/contracts.json
+          {
+            "development": {
+              "contracts": {
+                "Currency": {
+                  "deploy": true,
+                  "from": '0xfeedaa0e295b09cd84d6ea2cce390eb443bcfdfc',
+                  "args": [
+                    100
+                  ]
+                },
+                "MyStorage": {
+                  "fromIndex": 0,
+                  "args": [
+                    "initial string"
+                  ]
+                },
+              }
+            }
+          }
+            ...
 
 Contracts addresses can be defined, If an address is defined the
 contract wouldn't be deployed but its defined address will be used

--- a/lib/contracts/deploy.js
+++ b/lib/contracts/deploy.js
@@ -187,6 +187,18 @@ class Deploy {
             return next(new Error(err));
           }
           accounts = _accounts;
+
+          // applying deployer account configuration, if any
+          if (typeof contract.fromIndex == 'number') {
+            deploymentAccount = accounts[contract.fromIndex];
+          }
+          if (typeof contract.from == 'string' && typeof contract.fromIndex != 'undefined') {
+            self.logger.warn('Both "from" and "fromIndex" are defined for contract "'+contract.className+'". Using "from" as deployer account.');
+          }
+          if (typeof contract.from == 'string') {
+            deploymentAccount = contract.from;
+          }
+
           deploymentAccount = deploymentAccount || accounts[0];
           next();
         });


### PR DESCRIPTION
Fixing #319 .
Added handling of "from" and "fromIndex" of contract configuration.